### PR TITLE
remove btree intermediatory format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,13 +219,14 @@ dependencies = [
 
 [[package]]
 name = "get-config"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "confy",
  "inquire",
  "reqwest",
  "serde",
+ "serde-tuple-vec-map",
  "serde_json",
  "tokio",
 ]
@@ -784,6 +785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-tuple-vec-map"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "get-config"
 description = "pull your dot configs from a version controlled gists"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11.9", features = ["json"] }
 serde_json = "1.0"
+serde-tuple-vec-map = "1"
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 confy = "0.4.0"

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,7 +4,7 @@ use reqwest::{
     Client, Response,
 };
 use serde::Deserialize;
-use std::{collections::BTreeMap, time::SystemTime};
+use std::time::SystemTime;
 
 pub type Files = (String, File);
 pub type FilesVec = Vec<Files>;
@@ -21,7 +21,8 @@ pub struct File {
 #[derive(Deserialize, Debug)]
 pub struct GithubResponse {
     pub description: String,
-    pub files: BTreeMap<String, File>,
+    #[serde(with = "tuple_vec_map")]
+    pub files: Vec<(String, File)>,
 }
 
 fn parse_header_value(headers: &HeaderMap, name: &str, default: i64) -> i64 {
@@ -77,7 +78,7 @@ async fn parse_github_response(response: Response) -> Result<FilesVec> {
     match response.status().as_u16() {
         200 => match response.json::<GithubResponse>().await {
             Ok(res) => {
-                let mut files = Vec::from_iter(res.files);
+                let mut files = res.files;
                 files.sort_by_key(|a| a.1.truncated);
                 Ok(files)
             }


### PR DESCRIPTION
closes #1 

added: `serde-tuple-vec-map` as dependency